### PR TITLE
pom.xml now accesses maven-central using secure connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- CENTRAL repository -->
         <repository>
             <id>central</id>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
     


### PR DESCRIPTION
Using an unsecure connection caused "mvn install" in the root directory to fail on my machine. Changing to https resolved this isssue.